### PR TITLE
Add Missing )

### DIFF
--- a/authentication-filters.MD
+++ b/authentication-filters.MD
@@ -50,7 +50,7 @@ For example, if you have a custom post type Pod, you may wish to grant global ac
 
 ```php
 add_filter( 'pods_json_api_access_pods', function( $access ) {
-    if ( current_user_can( 'edit_posts' ) {
+    if ( current_user_can( 'edit_posts' )) {
         $access = true;
     }
   


### PR DESCRIPTION
should we add a note that anonymous functions only work with php >= 5.3 ? ( i know its no longer supported put Wordpress has 5.2? 
personally i just don't use em for filters ... somehow clutters the code for me
